### PR TITLE
Add Cypress E2E tests for Dashboard MessageList (#118)

### DIFF
--- a/client/cypress/e2e/dashboard.cy.ts
+++ b/client/cypress/e2e/dashboard.cy.ts
@@ -1,0 +1,160 @@
+// Valid fake JWT with payload {"email":"user@test.se","role":"USER"}
+const FAKE_JWT =
+  "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InVzZXJAdGVzdC5zZSIsInJvbGUiOiJVU0VSIn0.fakesignature";
+
+beforeEach(() => {
+  cy.intercept("GET", "**/api/**", {
+    statusCode: 200,
+    body: [],
+  }).as("backgroundApi");
+});
+
+describe("Dashboard - Message List Rendering", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/notifier/messages*", {
+      statusCode: 200,
+      fixture: "messages.json",
+    }).as("messages");
+
+    cy.intercept("POST", "**/api/**/login", {
+      statusCode: 200,
+      body: { success: true },
+    }).as("loginRequest");
+
+    cy.intercept("GET", "**/api/auth/me", {
+      statusCode: 200,
+      body: { email: "user@test.se", role: "USER" },
+    }).as("meRequest");
+
+    cy.visit("http://localhost:3000");
+    cy.get('input[type="email"]').type("user@test.se");
+    cy.get('input[type="password"]').type("password");
+    cy.setCookie("token", FAKE_JWT);
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest");
+    cy.location("pathname").should("eq", "/dashboard");
+  });
+
+  it("renders the MessageList heading", () => {
+    cy.contains("h1", "Dina senaste utskick").should("exist");
+  });
+
+  it("displays existing messages from the API", () => {
+    cy.contains("h2", "Utskick 1").should("exist");
+    cy.contains("h2", "Utskick 2").should("exist");
+    cy.contains("h2", "Utskick 3").should("exist");
+  });
+});
+
+describe("Dashboard - Navigation to Create", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "**/api/**/login", {
+      statusCode: 200,
+      body: { success: true },
+    }).as("loginRequest");
+
+    cy.intercept("GET", "**/api/auth/me", {
+      statusCode: 200,
+      body: { email: "user@test.se", role: "USER" },
+    }).as("meRequest");
+
+    cy.visit("http://localhost:3000");
+    cy.get('input[type="email"]').type("user@test.se");
+    cy.get('input[type="password"]').type("password");
+    cy.setCookie("token", FAKE_JWT);
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest");
+    cy.location("pathname").should("eq", "/dashboard");
+  });
+
+  it("navigates to the message creation page when 'Skapa nytt utskick' is clicked", () => {
+    cy.contains("button", "Skapa nytt utskick").click();
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard/messages");
+  });
+});
+
+describe("Dashboard - Message Interactivity", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/notifier/messages*", {
+      statusCode: 200,
+      fixture: "messages.json",
+    }).as("messages");
+
+    cy.intercept("POST", "**/api/**/login", {
+      statusCode: 200,
+      body: { success: true },
+    }).as("loginRequest");
+
+    cy.intercept("GET", "**/api/auth/me", {
+      statusCode: 200,
+      body: { email: "user@test.se", role: "USER" },
+    }).as("meRequest");
+
+    cy.visit("http://localhost:3000");
+    cy.get('input[type="email"]').type("user@test.se");
+    cy.get('input[type="password"]').type("password");
+    cy.setCookie("token", FAKE_JWT);
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest");
+    cy.location("pathname").should("eq", "/dashboard");
+    cy.contains("h2", "Utskick 1").should("exist");
+  });
+
+  it("navigates to the message detail view when an arrow button is clicked", () => {
+    cy.contains("h2", "Utskick 1")
+      .parent()
+      .siblings("button")
+      .click();
+
+    cy.location("pathname").should("eq", "/dashboard/messages/1");
+  });
+});
+
+describe("Dashboard - Display All Logic", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "**/api/notifier/messages*", {
+      statusCode: 200,
+      fixture: "messages.json",
+    }).as("messages");
+
+    cy.intercept("POST", "**/api/**/login", {
+      statusCode: 200,
+      body: { success: true },
+    }).as("loginRequest");
+
+    cy.intercept("GET", "**/api/auth/me", {
+      statusCode: 200,
+      body: { email: "user@test.se", role: "USER" },
+    }).as("meRequest");
+
+    cy.visit("http://localhost:3000");
+    cy.get('input[type="email"]').type("user@test.se");
+    cy.get('input[type="password"]').type("password");
+    cy.setCookie("token", FAKE_JWT);
+    cy.get('button[type="submit"]').click();
+    cy.wait("@loginRequest");
+    cy.location("pathname").should("eq", "/dashboard");
+    cy.contains("h2", "Utskick 1").should("exist");
+  });
+
+  it("shows only 3 messages initially when more than 3 exist", () => {
+    cy.get("h2.text-h3-sm").should("have.length", 3);
+  });
+
+  it("shows the 'Visa alla' button when more than 3 messages exist", () => {
+    cy.contains("button", "Visa alla").should("exist");
+  });
+
+  it("displays all messages after clicking 'Visa alla'", () => {
+    cy.contains("button", "Visa alla").click();
+    cy.get("h2.text-h3-sm").should("have.length", 4);
+    cy.contains("h2", "Utskick 4").should("exist");
+  });
+
+  it("collapses back to 3 messages after clicking 'Tillbaka'", () => {
+    cy.contains("button", "Visa alla").click();
+    cy.contains("button", "Tillbaka").click();
+    cy.get("h2.text-h3-sm").should("have.length", 3);
+    cy.contains("h2", "Utskick 4").should("not.exist");
+  });
+});

--- a/client/cypress/e2e/dashboard.cy.ts
+++ b/client/cypress/e2e/dashboard.cy.ts
@@ -1,3 +1,5 @@
+export {};
+
 // Valid fake JWT with payload {"email":"user@test.se","role":"USER"}
 const FAKE_JWT =
   "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InVzZXJAdGVzdC5zZSIsInJvbGUiOiJVU0VSIn0.fakesignature";
@@ -32,7 +34,7 @@ describe("Dashboard - Message List Rendering", () => {
     cy.setCookie("token", FAKE_JWT);
     cy.get('button[type="submit"]').click();
     cy.wait("@loginRequest");
-    cy.location("pathname").should("eq", "/dashboard");
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard");
   });
 
   it("renders the MessageList heading", () => {
@@ -64,7 +66,7 @@ describe("Dashboard - Navigation to Create", () => {
     cy.setCookie("token", FAKE_JWT);
     cy.get('button[type="submit"]').click();
     cy.wait("@loginRequest");
-    cy.location("pathname").should("eq", "/dashboard");
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard");
   });
 
   it("navigates to the message creation page when 'Skapa nytt utskick' is clicked", () => {
@@ -96,7 +98,7 @@ describe("Dashboard - Message Interactivity", () => {
     cy.setCookie("token", FAKE_JWT);
     cy.get('button[type="submit"]').click();
     cy.wait("@loginRequest");
-    cy.location("pathname").should("eq", "/dashboard");
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard");
     cy.contains("h2", "Utskick 1").should("exist");
   });
 
@@ -106,7 +108,7 @@ describe("Dashboard - Message Interactivity", () => {
       .siblings("button")
       .click();
 
-    cy.location("pathname").should("eq", "/dashboard/messages/1");
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard/messages/1");
   });
 });
 
@@ -133,7 +135,7 @@ describe("Dashboard - Display All Logic", () => {
     cy.setCookie("token", FAKE_JWT);
     cy.get('button[type="submit"]').click();
     cy.wait("@loginRequest");
-    cy.location("pathname").should("eq", "/dashboard");
+    cy.location("pathname", { timeout: 15000 }).should("eq", "/dashboard");
     cy.contains("h2", "Utskick 1").should("exist");
   });
 

--- a/client/cypress/fixtures/messages.json
+++ b/client/cypress/fixtures/messages.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": 1,
+    "title": "Utskick 1",
+    "content": "Testinnehåll för utskick 1",
+    "sender": "user@test.se",
+    "messageType": "SMS",
+    "createdAt": "2024-03-04T10:00:00.000Z",
+    "recipients": []
+  },
+  {
+    "id": 2,
+    "title": "Utskick 2",
+    "content": "Testinnehåll för utskick 2",
+    "sender": "user@test.se",
+    "messageType": "TEAMS",
+    "createdAt": "2024-03-03T10:00:00.000Z",
+    "recipients": []
+  },
+  {
+    "id": 3,
+    "title": "Utskick 3",
+    "content": "Testinnehåll för utskick 3",
+    "sender": "user@test.se",
+    "messageType": "SMS",
+    "createdAt": "2024-03-02T10:00:00.000Z",
+    "recipients": []
+  },
+  {
+    "id": 4,
+    "title": "Utskick 4",
+    "content": "Testinnehåll för utskick 4",
+    "sender": "user@test.se",
+    "messageType": "TEAMS",
+    "createdAt": "2024-03-01T10:00:00.000Z",
+    "recipients": []
+  }
+]

--- a/client/cypress/support/e2e.ts
+++ b/client/cypress/support/e2e.ts
@@ -15,3 +15,14 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+
+// Next.js HMR (hot module replacement) can emit chunks with syntax that the browser
+// flags as invalid while a live-reload is in flight. These errors are non-critical and
+// unrelated to test assertions, so we suppress them to avoid flaky test failures in
+// dev mode. In CI the app runs as a production build (yarn build && yarn start), so
+// this handler never fires there.
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('Invalid or unexpected token')) {
+    return false;
+  }
+});


### PR DESCRIPTION
 ## Summary
  - Adds `cypress/e2e/dashboard.cy.ts` with 8 E2E tests covering the MessageList component
  - Adds `cypress/fixtures/messages.json` with test data (4 messages)
  - Adds HMR SyntaxError handler in `cypress/support/e2e.ts` to prevent flaky failures in dev mode

  ## Tests
  | Acceptance criteria | Test(s) |
  |---|---|
  | MessageList renders on Dashboard | renders the MessageList heading, displays existing messages |
  | "New Message" navigates to create | navigates to message creation page when 'Skapa nytt utskick' is clicked |
  | Messages are clickable | navigates to message detail view when an arrow button is clicked |
  | "Visa alla" visar hela listan | shows 3 initially, button appears, shows all 4, collapses back |

Solves: #118 